### PR TITLE
docs: add badges, platform link, and contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PDF Autofillr
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tests](https://github.com/EngineersMind/pdf-autofillr/actions/workflows/mapper-tests.yml/badge.svg)](https://github.com/EngineersMind/pdf-autofillr/actions/workflows/mapper-tests.yml)
+[![Mapper Tests](https://github.com/EngineersMind/pdf-autofillr/actions/workflows/mapper-tests.yml/badge.svg?event=pull_request)](https://github.com/EngineersMind/pdf-autofillr/actions/workflows/mapper-tests.yml)
 [![Platform](https://img.shields.io/badge/platform-pdffillr.ai-blue)](https://pdffillr.ai)
 
 > **Live platform:** [pdffillr.ai](https://pdffillr.ai) — fill PDF forms in your browser with no setup.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # PDF Autofillr
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Tests](https://github.com/EngineersMind/pdf-autofillr/actions/workflows/mapper-tests.yml/badge.svg)](https://github.com/EngineersMind/pdf-autofillr/actions/workflows/mapper-tests.yml)
+[![Platform](https://img.shields.io/badge/platform-pdffillr.ai-blue)](https://pdffillr.ai)
+
+> **Live platform:** [pdffillr.ai](https://pdffillr.ai) — fill PDF forms in your browser with no setup.
+
 AI-powered PDF form filling system. Extracts fields from PDF forms, maps them to your data schema using an LLM, and fills them automatically.
 
 ---
@@ -223,6 +229,16 @@ venv/bin/python -m pytest tests/ -q
 | Module guides | [`docs/guides/`](docs/guides/) |
 | OpenAPI specs | [`sdks/`](sdks/) |
 | Benchmarks | [`benchmarks/README.md`](benchmarks/README.md) |
+
+---
+
+## Contributing
+
+Contributions are welcome! Read [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+
+- Report bugs via [GitHub Issues](https://github.com/EngineersMind/pdf-autofillr/issues)
+- See [good first issues](https://github.com/EngineersMind/pdf-autofillr/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) for beginner-friendly tasks
+- Review our [Code of Conduct](CODE_OF_CONDUCT.md) and [Security Policy](SECURITY.md)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add MIT license badge, CI test badge, and pdffillr.ai platform badge to README header
- Add callout linking to [pdffillr.ai](https://pdffillr.ai) live platform
- Add `## Contributing` section pointing to CONTRIBUTING.md, Issues, and Code of Conduct
- Align with open-source contribution patterns (Anthropic SDK style)

## Changes

- `README.md` — badges + platform link + contributing section

## Checklist
- [x] No logic changes — documentation only
- [x] Links verified against existing files (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md all exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)